### PR TITLE
正規表現エンジンが入れ子のStarでスタックオーバーフローする問題を回避

### DIFF
--- a/ch06/regex/src/engine/codegen.rs
+++ b/ch06/regex/src/engine/codegen.rs
@@ -53,7 +53,21 @@ impl Generator {
             AST::Char(c) => self.gen_char(*c)?,
             AST::Or(e1, e2) => self.gen_or(e1, e2)?,
             AST::Plus(e) => self.gen_plus(e)?,
-            AST::Star(e) => self.gen_star(e)?,
+            AST::Star(e1) => {
+                match &**e1 {
+                    // `(a*)*`のように`Star`が二重となっている場合にスタックオーバーフローする問題を回避するため、
+                    // このような`(((r*)*)*...*)*`を再帰的に処理して1つの`r*`へと変換する。
+                    AST::Star(e2) => self.gen_expr(&e2)?,
+                    AST::Seq(e2) if e2.len() == 1 =>
+                        if let Some(AST::Star(e3)) = e2.get(0) {
+                            self.gen_expr(&e3)?
+                        } else {
+                            self.gen_star(e1)?
+                        }
+                    e =>
+                        self.gen_star(&e)?
+                }
+            },
             AST::Question(e) => self.gen_question(e)?,
             AST::Seq(v) => self.gen_seq(v)?,
         }

--- a/ch06/regex/src/main.rs
+++ b/ch06/regex/src/main.rs
@@ -88,6 +88,7 @@ mod tests {
         assert!(do_matching("(abc)*", "abcabc", true).unwrap());
         assert!(do_matching("(ab|cd)+", "abcdcd", true).unwrap());
         assert!(do_matching("abc?", "ab", true).unwrap());
+        assert!(do_matching("((((a*)*)*)*)", "aaaaaaaaa", true).unwrap());
 
         // パース成功、マッチ失敗
         assert!(!do_matching("abc|def", "efa", true).unwrap());


### PR DESCRIPTION
「ゼロから学ぶRust」を楽しく読ませていただいています。
Rustの問題なのか（本の本質と関係あるか）どうか微妙なところですが、以前、Russ CoxのVM正規表現を自分も実装したことがあり、そのままだと入れ子になったスターを持つ`(a*)*`のような正規表現でスタックオーバーフローが生じてしまいます。
元の正規表現と等しいことをパッと証明はできませんし、これでどうして治るのかもよく分かってませんが、とりあえず`(r*)*`となっているところを再帰的に`r*`へ変換すれば大丈夫だと思いこのような修正を提案します。

### これまで

```console
$ cargo run "(a*)*" Cargo.toml
expr: (a*)*
AST: Seq([Star(Seq([Star(Char('a'))]))])

code:
0000: split 0001, 0005
0001: split 0002, 0004
0002: char a
0003: jump 0001
0004: jump 0000
0005: match


thread 'main' has overflowed its stack
fatal runtime error: stack overflow
zsh: abort      cargo run "(a*)*" Cargo.toml
```

### 修正後

```console
$ cargo run "(a*)*" Cargo.toml
expr: (a*)*
AST: Seq([Star(Seq([Star(Char('a'))]))])

code:
0000: char a
0001: match

[package]
name = "regex"
authors = ["Yuuki Takano <ytakanoster@gmail.com>"]
# See more keys and their definitions at https://doc.rust-lang.org/cargo/reference/manifest.html
name = "benchmark"
harness = false
```