### PR TITLE
正規表現におけるネストしたスターの動作を再修正

### DIFF
--- a/ch06/regex/src/engine/codegen.rs
+++ b/ch06/regex/src/engine/codegen.rs
@@ -59,8 +59,8 @@ impl Generator {
                     // このような`(((r*)*)*...*)*`を再帰的に処理して1つの`r*`へと変換する。
                     AST::Star(e2) => self.gen_expr(&e2)?,
                     AST::Seq(e2) if e2.len() == 1 =>
-                        if let Some(AST::Star(e3)) = e2.get(0) {
-                            self.gen_expr(&e3)?
+                        if let Some(e3 @ AST::Star(_)) = e2.get(0) {
+                            self.gen_expr(e3)?
                         } else {
                             self.gen_star(e1)?
                         }

--- a/ch06/regex/src/main.rs
+++ b/ch06/regex/src/main.rs
@@ -89,6 +89,7 @@ mod tests {
         assert!(do_matching("(ab|cd)+", "abcdcd", true).unwrap());
         assert!(do_matching("abc?", "ab", true).unwrap());
         assert!(do_matching("((((a*)*)*)*)", "aaaaaaaaa", true).unwrap());
+        assert!(do_matching("(a*)*b", "aaaaaaaaab", true).unwrap());
 
         // パース成功、マッチ失敗
         assert!(!do_matching("abc|def", "efa", true).unwrap());


### PR DESCRIPTION
- #4 で修理した内容を冷静にみると`(a*)*`で`split`が生成されなくなっていておかしいくしてしまっていた 😇 
    ```
    expr: (a*)*
    AST: Seq([Star(Seq([Star(Char('a'))]))])
    
    code:
    0000: char a
    0001: match
    ```
- `(r*)*`→`r*`とするはずが、誤って`(r*)*`→`r`としていたので修正した 🙇 
- 修正後は次のようなコードが生成される 🙆‍♀️ 
    ```
    expr: (a*)*
    AST: Seq([Star(Seq([Star(Char('a'))]))])
    
    code:
    0000: split 0001, 0003
    0001: char a
    0002: jump 0000
    0003: match
    ```
    - これは`a*`のコードと一致する 👍 
        ```
        expr: a*
        AST: Seq([Star(Char('a'))])
        
        code:
        0000: split 0001, 0003
        0001: char a
        0002: jump 0000
        0003: match
        ```