### PR TITLE
正規表現における連続したスターの動作を修正

### DIFF
--- a/ch06/regex/src/engine/codegen.rs
+++ b/ch06/regex/src/engine/codegen.rs
@@ -57,17 +57,17 @@ impl Generator {
                 match &**e1 {
                     // `(a*)*`のように`Star`が二重となっている場合にスタックオーバーフローする問題を回避するため、
                     // このような`(((r*)*)*...*)*`を再帰的に処理して1つの`r*`へと変換する。
-                    AST::Star(e2) => self.gen_expr(&e2)?,
-                    AST::Seq(e2) if e2.len() == 1 =>
+                    AST::Star(_) => self.gen_expr(&e1)?,
+                    AST::Seq(e2) if e2.len() == 1 => {
                         if let Some(e3 @ AST::Star(_)) = e2.get(0) {
                             self.gen_expr(e3)?
                         } else {
                             self.gen_star(e1)?
                         }
-                    e =>
-                        self.gen_star(&e)?
+                    }
+                    e => self.gen_star(&e)?,
                 }
-            },
+            }
             AST::Question(e) => self.gen_question(e)?,
             AST::Seq(v) => self.gen_seq(v)?,
         }

--- a/ch06/regex/src/main.rs
+++ b/ch06/regex/src/main.rs
@@ -90,6 +90,9 @@ mod tests {
         assert!(do_matching("abc?", "ab", true).unwrap());
         assert!(do_matching("((((a*)*)*)*)", "aaaaaaaaa", true).unwrap());
         assert!(do_matching("(a*)*b", "aaaaaaaaab", true).unwrap());
+        assert!(do_matching("(a*)*b", "b", true).unwrap());
+        assert!(do_matching("a**b", "aaaaaaaaab", true).unwrap());
+        assert!(do_matching("a**b", "b", true).unwrap());
 
         // パース成功、マッチ失敗
         assert!(!do_matching("abc|def", "efa", true).unwrap());


### PR DESCRIPTION
初めまして。当方はRust初学者ですが、「ゼロから学ぶRust」を読みながら楽しく勉強させてもらっています。
 本題ですが、[正規表現におけるネストしたスターの動作を再修正 #7](https://github.com/ytakano/rust_zero/pull/7)に類似した問題として、`a**`のようなスターが連続する正規表現を入力として与えた場合、生成されたコードから`split`が消えてしまっています。（下のコードブロックを参照）
```
expr: a**
AST: Seq([Star(Star(Char('a')))])

code:
0000: char a
0001: match
```

これを想定される出力が得られるよう修正しました。これは`a*`を入力として与えた場合と一致します。

```
expr: a**
AST: Seq([Star(Star(Char('a')))])

code:
0000: split 0001, 0003
0001: char a
0002: jump 0000
0003: match
```
通常の正規表現では`a**`の様な入力は構文エラーとみなされる様ですが（[参考](https://regexr.com/7cun7)）、修正後の挙動の方がコードの振る舞いとして自然であると考えたため本修正を提案させていただきます。

加えて、この修正と[正規表現におけるネストしたスターの動作を再修正 #7](https://github.com/ytakano/rust_zero/pull/7)の修正を検証できるようなテストを追加しました。