### PR TITLE
errata: Bashの正称を修正

### DIFF
--- a/errata.md
+++ b/errata.md
@@ -28,6 +28,7 @@
 | 4.4節。P.90。上のソースコードの6行目。 | `&js` | `&yml` |
 | 6.3.1項。P.136。上のソースコードの6行目。 | `espace` | `escape` |
 | 6.3節。P.141。ソースコード。 | 「`return Err(Box::new(..))`」となっている箇所 | このソースコード中でリターンしている箇所では、`Box::new()`は不要です |
+| 7.1節。P.167。下から5行目。 | Bourne Shell（Bash） | Bourne Again Shell（Bash） |
 | 7.3.4項。P.184。1行目。| `vec![("echo", vec!["hello"]), ("less", vec![])]` | `vec![("echo", vec!["echo", "hello"]), ("less", vec!["less"])]` |
 | 7.3.4項。P.196。ソースコード | 「`self.is_group_empty()`」を呼び出している箇所の`unwrap()` | `self.is_group_empty()`には、`unwrap()`は不要です |
 | 7.4節。P.201。演習問題3 | `nix::unistd::open` | `nix::fcntl::open` |


### PR DESCRIPTION
Bashの正称はBourne Shellではなく、Bourne Again Shellです。

>Bash is the GNU Project's shell—the Bourne Again SHell.

ref. https://www.gnu.org/software/bash/

BashとBourne Shellは別のシェルであり、BashはBourne Shellの後継シェルのうちの一つです。

>Bash contains features that appear in other popular shells, and some features that only appear in Bash. Some of the shells that Bash has borrowed concepts from are the Bourne Shell (sh), the Korn Shell (ksh), and the C-shell (csh and its successor, tcsh). 

ref. https://www.gnu.org/software/bash/manual/bash.html